### PR TITLE
Broaden intended readership & utility of this doc

### DIFF
--- a/security-privacy/index.src.html
+++ b/security-privacy/index.src.html
@@ -8,14 +8,16 @@ Editor: Mike West, Google Inc., mkwst@google.com
 Group: personal
 Indent: 2
 Abstract: 
-  This document lists a set of questions that working groups interested in the
-  security and privacy impacts of their specifications might ask themselves.
-  It is not meant as a "security checklist", nor does filling out this
-  questionnaire obviate the group's responsibility to obtain "wide review" of
-  a specification's security and privacy properties before publication.
-  Instead, this document is meant as a guide through an initial self-review,
-  which can provide a later reviewer with valuable context, and help a group
-  to focus on important questions in areas where they might lack expertise.
+  This document lists a set of questions you can ask about the security
+  and privacy impact of a specification.
+  It is not meant as a "security checklist", nor does an editor or group
+  filling out this questionnaire obviate the editor or group's
+  responsibility to obtain "wide review" of a specification's security
+  and privacy properties before publication.
+  Instead, this document is meant as a review guide for anyone to use—to
+  provide later reviewers with valuable context, and to help readers and
+  editors and groups focus on important questions in areas where they
+  might lack expertise.
 </pre>
 <div boilerplate=copyright>
 &copy;2014 Google
@@ -42,11 +44,12 @@ Abstract:
   depend on a particular implementation. 
 
   This document encourages early review by posing a number of questions that
-  a working group might consider themselves, before asking for more formal
-  review. The intent is to highligh areas which have historically had
+  you as a individual reader of a specification can ask—and that working
+  groups and spec editors might consider themselves, before asking for more
+  formal review. The intent is to highlight areas which have historically had
   interesting implications on a user's security or privacy, and thereby to
-  focus the working group's attention on areas that might previously have been
-  overlooked.
+  focus the editor's attention and working group's attention and reviewers'
+  attention on areas that might previously have been overlooked.
 
   Note: Answering these questions obviously doesn't constitute "wide review" in
   and of itself, but could provide a helpful basis of understanding upon which


### PR DESCRIPTION
This doc is a very useful tool for guiding *anyone* reading a spec to focus their attention in the right places and to understand what questions to ask. It helps gets everybody on the same page—editors, WG members, and 3rd-party reader/reviewers—so it’d be helpful to make the abstract and intro more welcoming to readers, and more inclusive.